### PR TITLE
Remove refurbished listing from eBay

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ As per the [HP Dev One Website](https://hpdevone.com), the HP Dev One has sold o
 
 > We have sold out of all HP Dev One PCs and our dedicated support team is still available to assist you for 3-years from purchase. To contact support, please sign into your HP account and submit a ticket.
 
-🟥 **There are currently factory refurbished units sold on [eBay](https://www.ebay.com/itm/295477381703) for less than $600.**
-
 This Guide will continue to be updated and is looking forward to more content to be added by the HP Dev One owners, the community and the maintainers.
 
 ## Coupon Code


### PR DESCRIPTION
The eBay listing for refurbished models of the HP Dev One has sold out and is out of date.

I have a [capture](https://web.archive.org/web/20230218092949/https://www.ebay.com/itm/295477381703) on the [Wayback Machine](https://en.wikipedia.org/wiki/Wayback_Machine) and a [capture](https://archive.is/zI5oa) on [archive&period;today](https://en.wikipedia.org/wiki/Archive.today).